### PR TITLE
disable prometheus by env var

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -129,6 +129,11 @@ func init() {
 		port = fmt.Sprintf(":%s", envPort)
 	}
 	go func() {
+		envDisabled, _ := os.LookupEnv("EVENTSGATEWAY_PROMETHEUS_DISABLED")
+		if envDisabled == "true" {
+			return
+		}
+
 		r := mux.NewRouter()
 		r.Handle("/metrics", promhttp.Handler())
 


### PR DESCRIPTION
Add an env var to disable Prometheus server start.

I think the default should be to not start Prometheus, but this way will keep retro-compatibility with running servers. 