### PR TITLE
[*] Reducing Metrics Generated to Prometheus

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -185,13 +185,13 @@ func (a *App) metricsReporterInterceptor(
 	reportedFailures := false
 	res, err := handler(ctx, req)
 	if err != nil {
-		l.WithError(err).Error("error processing request")
+		l.WithError(err).Error(err.Error())
 		for _, e := range events {
 			metrics.APIRequestsFailureCounter.WithLabelValues(
 				info.FullMethod,
 				e.Topic,
 				retry,
-				err.Error(),
+				"error processing request",
 			).Inc()
 		}
 		reportedFailures = true

--- a/app/app.go
+++ b/app/app.go
@@ -185,7 +185,7 @@ func (a *App) metricsReporterInterceptor(
 	reportedFailures := false
 	res, err := handler(ctx, req)
 	if err != nil {
-		l.WithError(err).Error(err.Error())
+		l.WithError(err).Error("error processing request")
 		for _, e := range events {
 			metrics.APIRequestsFailureCounter.WithLabelValues(
 				info.FullMethod,


### PR DESCRIPTION
Currently the failure counter is creating dumps os errors in the reason label. This generates thousands of metrics, as the label differs one from another.

A simple example:
```
# HELP eventsgateway_api_requests_failure_counter A counter of failed api requests
# TYPE eventsgateway_api_requests_failure_counter counter
eventsgateway_api_requests_failure_counter{reason="dial tcp 10.0.10.49:9092: connect: connection refused",retry="0",route="/example",topic="events"} 3
eventsgateway_api_requests_failure_counter{reason="dial tcp 10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 32
eventsgateway_api_requests_failure_counter{reason="dial tcp 10.0.3.21:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="kafka server: Tried to send a message to a replica that is not the leader for some partition. Your metadata is out of date.",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="kafka: broker not connected",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:32768->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:32788->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:32858->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:32886->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:33332->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:33534->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:33574->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:33606->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:34030->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:34076->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:34152->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:34274->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 3
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:34360->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:34472->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:34474->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:34588->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:34634->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:34714->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:37122->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:37370->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:37438->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:37526->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:37978->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:38014->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:38110->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:38206->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:38286->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:38328->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:38392->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:38454->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:38520->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:38608->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:38704->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:38786->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:38834->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:38970->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:39026->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:39072->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:39084->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 3
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:39136->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 3
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:39162->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:39318->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:39326->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:39396->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:39406->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:39526->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:39584->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:39662->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:39882->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:39906->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:40004->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:40048->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:40048->10.0.3.21:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:40216->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:40234->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 3
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:40270->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:40380->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:40456->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:40492->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:40560->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:40962->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:40980->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:41032->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:41098->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:41116->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:41184->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:41286->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:41434->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:41510->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:42608->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:42652->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:42860->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:42948->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:42964->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:43090->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:43176->10.0.3.21:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:43190->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:43218->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:43248->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:43272->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:43326->10.0.3.21:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:43414->10.0.3.21:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:43448->10.0.3.21:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:43634->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:43770->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:43858->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:43892->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:43948->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:43978->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:44038->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:44164->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:44254->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:44290->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:44440->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:44464->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:44478->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:44498->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:44606->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:44780->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:44792->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:44800->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:44820->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 3
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:44832->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:44866->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:44874->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:44888->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:44934->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:44968->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:45008->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:45042->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:45330->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:45410->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:45590->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:45664->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:45712->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:45952->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46030->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46052->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46112->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46122->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46136->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46152->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46276->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46312->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46354->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46372->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46374->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46428->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46472->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46490->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46522->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46560->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46574->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46760->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46774->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46794->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46892->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46974->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46978->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:46994->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:47004->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:47046->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 3
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:47058->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:47068->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:47120->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 4
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:47144->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:47148->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:47170->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:47592->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:47796->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:47822->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:47882->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:47914->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:47952->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:47970->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:48038->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:48050->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:48096->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:48124->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:48146->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:48150->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:48168->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:48180->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:48202->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:48218->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:48664->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:49040->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:49050->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:49090->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:49108->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:49126->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:49132->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:49144->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:49240->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:49306->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:49400->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:49702->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:49764->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:49900->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:50344->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:50638->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:50822->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 4
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:50838->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:50850->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:50882->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:50912->10.0.3.21:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:50942->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:50960->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:50968->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 3
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:51096->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:51122->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:51148->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 3
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:51254->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:51314->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:51434->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:51572->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:51652->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:51660->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:51694->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:51724->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:51824->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:51976->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52024->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52058->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52108->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52118->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52220->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 3
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52298->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52308->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52326->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52374->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52392->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52492->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52658->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52762->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52776->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52814->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52818->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52830->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52860->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52874->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52876->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52898->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52940->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52966->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52970->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:52988->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:53004->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:53028->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:53044->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 3
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:53062->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:53080->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:53110->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:53112->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:53130->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:53214->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:53232->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:53256->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:53272->10.0.3.21:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:53274->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:53348->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:53434->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:53458->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:53556->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:53560->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:54118->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:54288->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:54310->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:54434->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:54462->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55534->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 4
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55552->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55572->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55590->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55594->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55604->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55616->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55648->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55698->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55722->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55770->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55800->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55818->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55860->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55880->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55894->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55898->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55934->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55948->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55960->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:55990->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:56064->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:56082->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:56122->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:56128->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:56148->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:56184->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:56192->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:56222->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:56292->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:56698->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:56720->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:56768->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:56786->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:56820->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:56892->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:56914->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:57080->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:57130->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:57214->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:57222->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:57318->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:57328->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:57484->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:57570->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:57586->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:57602->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:57614->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:57782->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:57862->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:57886->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:58574->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:58670->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:58798->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:58848->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:59030->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:59098->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:59166->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:59182->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:59202->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:59234->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:59302->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:59344->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:59364->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:59422->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:59522->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:59562->10.0.3.21:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:59628->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:59718->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:59746->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:59850->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:59882->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:59922->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:59954->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60054->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60192->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60212->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60272->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60276->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60302->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60326->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60338->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60352->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60358->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60370->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60378->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60390->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60404->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60408->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60434->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60450->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60478->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 4
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60498->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60518->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 3
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60526->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60532->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60564->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60590->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60616->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60644->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60674->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60692->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60714->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60732->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60760->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60772->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60804->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60810->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 1
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60862->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
eventsgateway_api_requests_failure_counter{reason="read tcp 10.136.5.77:60916->10.0.10.49:9092: i/o timeout",retry="0",route="/example",topic="events"} 2
```

Those kind of errors shouldn't be dumped on a prometheus metrics label, so I'm logging those errors and creating a simple metrics.