### PR TITLE
Add support to allow event timestamp customisation

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -128,12 +128,13 @@ var _ = Describe("Client", func() {
 		})
 
 		It("should fail if event forward fails", func() {
+			topic := "custom-topic"
 			mockGRPCClient.EXPECT().SendEvent(
 				gomock.Any(),
 				gomock.Any(),
 			).Return(nil, errors.New("olar"))
 
-			err := c.Send(context.Background(), name, props)
+			err := c.SendToTopic(context.Background(), name, props, topic)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("olar"))
 		})


### PR DESCRIPTION
**This merge request:**
* Allow event timestamp customisation.
* Fix an existing test case that was testing the wrong method.

We need this method to implement an alternative solution for sending events in a particular game (Tennis). This maybe a temporary solution for us, it depends on the results.