### PR TITLE
Remove logrus from API and use a generic logger interface instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ About client.NewClient(...) arguments:
 
 * configPrefix: whatever comes just before `client` portion of your config
 * config: a viper config with at least a `client` key holding Events Gateway settings
-* logger: a logrus.FieldLogger instance
+* logger: a logger.Logger instance
 * client: should be nil for most cases, except for unit testing
 * opts: extra []grpc.DialOption objects
 
@@ -45,14 +45,14 @@ import (
 
   "github.com/spf13/viper"
   "github.com/topfreegames/eventsgateway"
-  "github.com/sirupsen/logrus"
+  "github.com/topfreegames/eventsgateway/logger"
 )
 
 func ConfigureEventsGateway() (*eventsgateway.Client, error) {
   config := viper.New() // empty Viper config
   config.Set("eventsgateway.client.async", true)
   config.Set("eventsgateway.client.kafkatopic", "my-client-default-topic")
-  logger := logrus.WithFields(logrus.Fields{"some": "field"})
+  logger := &logger.NullLogger{} // Initialize you logger.Logger implementation here
   client, err := eventsgateway.NewClient("eventsgateway", config, logger, nil)
   if err != nil {
     return nil, err

--- a/app/app.go
+++ b/app/app.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	goMetrics "github.com/rcrowley/go-metrics"
+	"github.com/topfreegames/eventsgateway/logger"
 	"github.com/topfreegames/eventsgateway/metrics"
 	"github.com/topfreegames/eventsgateway/sender"
 	"github.com/topfreegames/extensions/jaeger"
@@ -46,8 +47,6 @@ import (
 	"github.com/spf13/viper"
 	kafka "github.com/topfreegames/go-extensions-kafka"
 	pb "github.com/topfreegames/protos/eventsgateway/grpc/generated"
-
-	"github.com/sirupsen/logrus"
 )
 
 // App is the app structure
@@ -56,12 +55,12 @@ type App struct {
 	config     *viper.Viper
 	grpcServer *grpc.Server
 	host       string
-	log        logrus.FieldLogger
+	log        logger.Logger
 	port       int
 }
 
 // NewApp creates a new App object
-func NewApp(host string, port int, log logrus.FieldLogger, config *viper.Viper) (*App, error) {
+func NewApp(host string, port int, log logger.Logger, config *viper.Viper) (*App, error) {
 	a := &App{
 		host:   host,
 		port:   port,

--- a/app/server.go
+++ b/app/server.go
@@ -25,19 +25,19 @@ package app
 import (
 	"context"
 
-	"github.com/sirupsen/logrus"
+	"github.com/topfreegames/eventsgateway/logger"
 	"github.com/topfreegames/eventsgateway/sender"
 	pb "github.com/topfreegames/protos/eventsgateway/grpc/generated"
 )
 
 // Server struct
 type Server struct {
-	logger logrus.FieldLogger
+	logger logger.Logger
 	sender sender.Sender
 }
 
 // NewServer returns a new grpc server
-func NewServer(sender sender.Sender, logger logrus.FieldLogger) *Server {
+func NewServer(sender sender.Sender, logger logger.Logger) *Server {
 	s := &Server{
 		logger: logger,
 		sender: sender,

--- a/app/server_suite_test.go
+++ b/app/server_suite_test.go
@@ -27,12 +27,11 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spf13/viper"
 
 	"testing"
 
+	"github.com/topfreegames/eventsgateway/logger"
 	"github.com/topfreegames/eventsgateway/mocks"
 	. "github.com/topfreegames/eventsgateway/testing"
 	mockpb "github.com/topfreegames/protos/eventsgateway/grpc/mock"
@@ -45,16 +44,14 @@ func TestClient(t *testing.T) {
 
 var (
 	config         *viper.Viper
-	hook           *test.Hook
-	logger         *logrus.Logger
+	log            logger.Logger
 	mockCtrl       *gomock.Controller
 	mockGRPCServer *mockpb.MockGRPCForwarderServer
 	mockForwarder  *mocks.MockForwarder
 )
 
 var _ = BeforeEach(func() {
-	logger, hook = test.NewNullLogger()
-	logger.Level = logrus.DebugLevel
+	log = &logger.NullLogger{}
 	config, _ = GetDefaultConfig()
 
 	mockCtrl = gomock.NewController(GinkgoT())

--- a/app/server_test.go
+++ b/app/server_test.go
@@ -24,8 +24,8 @@ var _ = Describe("Client", func() {
 
 	BeforeEach(func() {
 		nowMs = time.Now().UnixNano() / 1000000
-		sender := sender.NewKafkaSender(mockForwarder, logger, config)
-		s = app.NewServer(sender, logger)
+		sender := sender.NewKafkaSender(mockForwarder, log, config)
+		s = app.NewServer(sender, log)
 		Expect(s).NotTo(BeNil())
 	})
 

--- a/client/client.go
+++ b/client/client.go
@@ -15,8 +15,8 @@ import (
 	"time"
 
 	uuid "github.com/satori/go.uuid"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+	"github.com/topfreegames/eventsgateway/logger"
 	pb "github.com/topfreegames/protos/eventsgateway/grpc/generated"
 	"google.golang.org/grpc"
 )
@@ -25,7 +25,7 @@ import (
 type Client struct {
 	client        GRPCClient
 	config        *viper.Viper
-	logger        logrus.FieldLogger
+	logger        logger.Logger
 	topic         string
 	wg            sync.WaitGroup
 	serverAddress string
@@ -36,7 +36,7 @@ type Client struct {
 func NewClient(
 	configPrefix string,
 	config *viper.Viper,
-	logger logrus.FieldLogger,
+	logger logger.Logger,
 	client pb.GRPCForwarderClient,
 	opts ...grpc.DialOption,
 ) (*Client, error) {
@@ -52,7 +52,7 @@ func NewClient(
 	if c.topic == "" {
 		return nil, fmt.Errorf("no kafka topic informed at %s", topicConf)
 	}
-	c.logger = c.logger.WithFields(logrus.Fields{
+	c.logger = c.logger.WithFields(map[string]interface{}{
 		"source": "eventsgateway/client",
 		"topic":  c.topic,
 	})
@@ -76,7 +76,7 @@ func (c *Client) newGRPCClient(
 	asyncConf := fmt.Sprintf("%sclient.async", configPrefix)
 	c.config.SetDefault(asyncConf, false)
 	async := c.config.GetBool(asyncConf)
-	c.logger = c.logger.WithFields(logrus.Fields{
+	c.logger = c.logger.WithFields(map[string]interface{}{
 		"serverAddress": c.serverAddress,
 		"async":         async,
 	})
@@ -92,7 +92,7 @@ func (c *Client) Send(
 	name string,
 	props map[string]string,
 ) error {
-	l := c.logger.WithFields(logrus.Fields{
+	l := c.logger.WithFields(map[string]interface{}{
 		"operation": "send",
 		"event":     name,
 	})
@@ -111,7 +111,7 @@ func (c *Client) SendToTopic(
 	props map[string]string,
 	topic string,
 ) error {
-	l := c.logger.WithFields(logrus.Fields{
+	l := c.logger.WithFields(map[string]interface{}{
 		"operation": "sendToTopic",
 		"event":     name,
 		"topic":     topic,

--- a/client/client.go
+++ b/client/client.go
@@ -15,8 +15,10 @@ import (
 	"time"
 
 	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/topfreegames/eventsgateway/logger"
+	logruswrapper "github.com/topfreegames/eventsgateway/logger/logrus"
 	pb "github.com/topfreegames/protos/eventsgateway/grpc/generated"
 	"google.golang.org/grpc"
 )
@@ -31,9 +33,21 @@ type Client struct {
 	serverAddress string
 }
 
-// NewClient ctor
+// NewClient ctor (DEPRECATED, use New() instead)
 // configPrefix is whatever comes before `client` subpart of config
 func NewClient(
+	configPrefix string,
+	config *viper.Viper,
+	logger logrus.FieldLogger,
+	client pb.GRPCForwarderClient,
+	opts ...grpc.DialOption,
+) (*Client, error) {
+	return New(configPrefix, config, logruswrapper.NewWithLogger(logger), client, opts...)
+}
+
+// New ctor
+// configPrefix is whatever comes before `client` subpart of config
+func New(
 	configPrefix string,
 	config *viper.Viper,
 	logger logger.Logger,

--- a/client/client_suite_test.go
+++ b/client/client_suite_test.go
@@ -12,9 +12,8 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spf13/viper"
+	"github.com/topfreegames/eventsgateway/logger"
 
 	"testing"
 
@@ -29,15 +28,13 @@ func TestClient(t *testing.T) {
 
 var (
 	config         *viper.Viper
-	hook           *test.Hook
-	logger         *logrus.Logger
+	log            logger.Logger
 	mockCtrl       *gomock.Controller
 	mockGRPCClient *mockpb.MockGRPCForwarderClient
 )
 
 var _ = BeforeEach(func() {
-	logger, hook = test.NewNullLogger()
-	logger.Level = logrus.DebugLevel
+	log = &logger.NullLogger{}
 	config, _ = GetDefaultConfig()
 
 	mockCtrl = gomock.NewController(GinkgoT())

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -34,21 +34,21 @@ var _ = Describe("Client", func() {
 
 	BeforeEach(func() {
 		var err error
-		c, err = client.NewClient("", config, logger, mockGRPCClient)
+		c, err = client.NewClient("", config, log, mockGRPCClient)
 		Expect(err).NotTo(HaveOccurred())
 		now = time.Now().UnixNano() / 1000000
 	})
 
 	Describe("NewClient", func() {
 		It("should return client if no error", func() {
-			c, err := client.NewClient("", config, logger, mockGRPCClient)
+			c, err := client.NewClient("", config, log, mockGRPCClient)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c).NotTo(BeNil())
 		})
 
 		It("should return an error if no kafka topic", func() {
 			config.Set("client.kafkatopic", "")
-			c, err := client.NewClient("", config, logger, mockGRPCClient)
+			c, err := client.NewClient("", config, log, mockGRPCClient)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("no kafka topic informed"))
 			Expect(c).To(BeNil())
@@ -56,7 +56,7 @@ var _ = Describe("Client", func() {
 
 		It("should return an error if no server address", func() {
 			config.Set("client.grpc.serveraddress", "")
-			c, err := client.NewClient("", config, logger, mockGRPCClient)
+			c, err := client.NewClient("", config, log, mockGRPCClient)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("no grpc server address informed"))
 			Expect(c).To(BeNil())
@@ -76,7 +76,7 @@ var _ = Describe("Client", func() {
 
 		BeforeEach(func() {
 			var err error
-			c, err = client.NewClient("", config, logger, mockGRPCClient)
+			c, err = client.NewClient("", config, log, mockGRPCClient)
 			Expect(err).NotTo(HaveOccurred())
 			now = time.Now().UnixNano() / int64(time.Millisecond)
 		})

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -34,21 +34,21 @@ var _ = Describe("Client", func() {
 
 	BeforeEach(func() {
 		var err error
-		c, err = client.NewClient("", config, log, mockGRPCClient)
+		c, err = client.New("", config, log, mockGRPCClient)
 		Expect(err).NotTo(HaveOccurred())
 		now = time.Now().UnixNano() / 1000000
 	})
 
 	Describe("NewClient", func() {
 		It("should return client if no error", func() {
-			c, err := client.NewClient("", config, log, mockGRPCClient)
+			c, err := client.New("", config, log, mockGRPCClient)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c).NotTo(BeNil())
 		})
 
 		It("should return an error if no kafka topic", func() {
 			config.Set("client.kafkatopic", "")
-			c, err := client.NewClient("", config, log, mockGRPCClient)
+			c, err := client.New("", config, log, mockGRPCClient)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("no kafka topic informed"))
 			Expect(c).To(BeNil())
@@ -56,7 +56,7 @@ var _ = Describe("Client", func() {
 
 		It("should return an error if no server address", func() {
 			config.Set("client.grpc.serveraddress", "")
-			c, err := client.NewClient("", config, log, mockGRPCClient)
+			c, err := client.New("", config, log, mockGRPCClient)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("no grpc server address informed"))
 			Expect(c).To(BeNil())
@@ -76,7 +76,7 @@ var _ = Describe("Client", func() {
 
 		BeforeEach(func() {
 			var err error
-			c, err = client.NewClient("", config, log, mockGRPCClient)
+			c, err = client.New("", config, log, mockGRPCClient)
 			Expect(err).NotTo(HaveOccurred())
 			now = time.Now().UnixNano() / int64(time.Millisecond)
 		})

--- a/client/client_whitebox_test.go
+++ b/client/client_whitebox_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Client Whitebox", func() {
 		mockCtrl := gomock.NewController(GinkgoT())
 		mockGRPCClient := mockpb.NewMockGRPCForwarderClient(mockCtrl)
 		config.Set("client.async", true)
-		c, err = NewClient(
+		c, err = New(
 			"",
 			config,
 			logruswrapper.NewWithLogger(logger),

--- a/client/client_whitebox_test.go
+++ b/client/client_whitebox_test.go
@@ -15,6 +15,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	logruswrapper "github.com/topfreegames/eventsgateway/logger/logrus"
 	. "github.com/topfreegames/eventsgateway/testing"
 	mockpb "github.com/topfreegames/protos/eventsgateway/grpc/mock"
 )
@@ -36,7 +37,7 @@ var _ = Describe("Client Whitebox", func() {
 		c, err = NewClient(
 			"",
 			config,
-			logger,
+			logruswrapper.NewWithLogger(logger),
 			mockGRPCClient,
 		)
 		Expect(err).NotTo(HaveOccurred())

--- a/client/sync_test.go
+++ b/client/sync_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Sync Client", func() {
 
 	BeforeEach(func() {
 		var err error
-		c, err = client.NewClient("", config, logger, mockGRPCClient)
+		c, err = client.NewClient("", config, log, mockGRPCClient)
 		Expect(err).NotTo(HaveOccurred())
 		now = time.Now().UnixNano() / 1000000
 	})
@@ -52,7 +52,7 @@ var _ = Describe("Sync Client", func() {
 
 		BeforeEach(func() {
 			var err error
-			c, err = client.NewClient("", config, logger, mockGRPCClient)
+			c, err = client.NewClient("", config, log, mockGRPCClient)
 			Expect(err).NotTo(HaveOccurred())
 			now = time.Now().UnixNano() / 1000000
 		})

--- a/client/sync_test.go
+++ b/client/sync_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Sync Client", func() {
 
 	BeforeEach(func() {
 		var err error
-		c, err = client.NewClient("", config, log, mockGRPCClient)
+		c, err = client.New("", config, log, mockGRPCClient)
 		Expect(err).NotTo(HaveOccurred())
 		now = time.Now().UnixNano() / 1000000
 	})
@@ -52,7 +52,7 @@ var _ = Describe("Sync Client", func() {
 
 		BeforeEach(func() {
 			var err error
-			c, err = client.NewClient("", config, log, mockGRPCClient)
+			c, err = client.New("", config, log, mockGRPCClient)
 			Expect(err).NotTo(HaveOccurred())
 			now = time.Now().UnixNano() / 1000000
 		})

--- a/cmd/load-test.go
+++ b/cmd/load-test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/topfreegames/eventsgateway/loadtest"
+	logruswrapper "github.com/topfreegames/eventsgateway/logger/logrus"
 )
 
 // loadTest represents the testclient command
@@ -41,7 +42,7 @@ var loadTest = &cobra.Command{
 		if json {
 			log.Formatter = new(logrus.JSONFormatter)
 		}
-		tc, err := loadtest.NewLoadTest(log, config)
+		tc, err := loadtest.NewLoadTest(logruswrapper.NewWithLogger(log), config)
 		if err != nil {
 			log.Panic(err)
 		}

--- a/cmd/producer.go
+++ b/cmd/producer.go
@@ -25,6 +25,7 @@ package cmd
 import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	logruswrapper "github.com/topfreegames/eventsgateway/logger/logrus"
 	"github.com/topfreegames/eventsgateway/producer"
 )
 
@@ -41,7 +42,7 @@ var producerCMD = &cobra.Command{
 		if json {
 			log.Formatter = new(logrus.JSONFormatter)
 		}
-		p, err := producer.NewProducer(log, config)
+		p, err := producer.NewProducer(logruswrapper.NewWithLogger(log), config)
 		if err != nil {
 			log.Panic(err)
 		}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/topfreegames/eventsgateway/app"
+	logruswrapper "github.com/topfreegames/eventsgateway/logger/logrus"
 )
 
 var host string
@@ -44,7 +45,7 @@ var startCmd = &cobra.Command{
 		if json {
 			log.Formatter = new(logrus.JSONFormatter)
 		}
-		a, err := app.NewApp(host, port, log, config)
+		a, err := app.NewApp(host, port, logruswrapper.NewWithLogger(log), config)
 		if err != nil {
 			log.Panic(err)
 		}

--- a/loadtest/loadtest.go
+++ b/loadtest/loadtest.go
@@ -31,22 +31,21 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
-
-	"github.com/sirupsen/logrus"
+	"github.com/topfreegames/eventsgateway/logger"
 )
 
 // LoadTest holds runners clients
 type LoadTest struct {
 	config   *viper.Viper
 	duration time.Duration
-	log      logrus.FieldLogger
+	log      logger.Logger
 	threads  int
 	runners  []*runner
 	wg       sync.WaitGroup
 }
 
 // NewLoadTest ctor
-func NewLoadTest(log logrus.FieldLogger, config *viper.Viper) (*LoadTest, error) {
+func NewLoadTest(log logger.Logger, config *viper.Viper) (*LoadTest, error) {
 	rand.Seed(time.Now().Unix())
 	lt := &LoadTest{
 		log:    log,

--- a/loadtest/runner.go
+++ b/loadtest/runner.go
@@ -58,7 +58,7 @@ func newRunner(
 
 func (r *runner) configure() error {
 	r.config.Set("client.kafkatopic", randomTopic())
-	c, err := client.NewClient("", r.config, r.log, nil)
+	c, err := client.New("", r.config, r.log, nil)
 	if err != nil {
 		return err
 	}

--- a/loadtest/runner.go
+++ b/loadtest/runner.go
@@ -30,15 +30,14 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/spf13/viper"
 	"github.com/topfreegames/eventsgateway/client"
-
-	"github.com/sirupsen/logrus"
+	"github.com/topfreegames/eventsgateway/logger"
 )
 
 type runner struct {
 	client             *client.Client
 	config             *viper.Viper
 	duration           time.Duration
-	log                logrus.FieldLogger
+	log                logger.Logger
 	randPropsSize      string
 	randSleepCeilingMs int
 	sentCounter        uint64
@@ -46,7 +45,7 @@ type runner struct {
 }
 
 func newRunner(
-	log logrus.FieldLogger, config *viper.Viper,
+	log logger.Logger, config *viper.Viper,
 ) (*runner, error) {
 	rand.Seed(time.Now().Unix())
 	r := &runner{

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,32 @@
+package logger
+
+// Logger interface for loggers
+type Logger interface {
+	Fatal(format ...interface{})
+	Fatalf(format string, args ...interface{})
+	Fatalln(args ...interface{})
+
+	Debug(args ...interface{})
+	Debugf(format string, args ...interface{})
+	Debugln(args ...interface{})
+
+	Error(args ...interface{})
+	Errorf(format string, args ...interface{})
+	Errorln(args ...interface{})
+
+	Info(args ...interface{})
+	Infof(format string, args ...interface{})
+	Infoln(args ...interface{})
+
+	Warn(args ...interface{})
+	Warnf(format string, args ...interface{})
+	Warnln(args ...interface{})
+
+	Panic(args ...interface{})
+	Panicf(format string, args ...interface{})
+	Panicln(args ...interface{})
+
+	WithFields(fields map[string]interface{}) Logger
+	WithField(key string, value interface{}) Logger
+	WithError(err error) Logger
+}

--- a/logger/logrus/logrus.go
+++ b/logger/logrus/logrus.go
@@ -1,0 +1,105 @@
+package logrus
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/topfreegames/eventsgateway/logger"
+)
+
+type logrusImpl struct {
+	impl logrus.FieldLogger
+}
+
+// New returns a new logger.Logger implementation based on logrus
+func New() logger.Logger {
+	log := logrus.New()
+	return NewWithLogger(log)
+}
+
+// NewWithLogger returns a new logger.Logger implementation based on a provided logrus instance
+func NewWithLogger(logger logrus.FieldLogger) logger.Logger {
+	return &logrusImpl{impl: logger}
+}
+
+func (l *logrusImpl) Fatal(format ...interface{}) {
+	l.impl.Fatal(format...)
+}
+
+func (l *logrusImpl) Fatalf(format string, args ...interface{}) {
+	l.impl.Fatalf(format, args...)
+}
+
+func (l *logrusImpl) Fatalln(args ...interface{}) {
+	l.impl.Fatalln(args...)
+}
+
+func (l *logrusImpl) Debug(args ...interface{}) {
+	l.impl.Debug(args...)
+}
+
+func (l *logrusImpl) Debugf(format string, args ...interface{}) {
+	l.impl.Debugf(format, args...)
+}
+
+func (l *logrusImpl) Debugln(args ...interface{}) {
+	l.impl.Debugln(args...)
+}
+
+func (l *logrusImpl) Error(args ...interface{}) {
+	l.impl.Error(args...)
+}
+
+func (l *logrusImpl) Errorf(format string, args ...interface{}) {
+	l.impl.Errorf(format, args...)
+}
+
+func (l *logrusImpl) Errorln(args ...interface{}) {
+	l.impl.Errorln(args...)
+}
+
+func (l *logrusImpl) Info(args ...interface{}) {
+	l.impl.Info(args...)
+}
+
+func (l *logrusImpl) Infof(format string, args ...interface{}) {
+	l.impl.Infof(format, args...)
+}
+
+func (l *logrusImpl) Infoln(args ...interface{}) {
+	l.impl.Infoln(args...)
+}
+
+func (l *logrusImpl) Warn(args ...interface{}) {
+	l.impl.Warn(args...)
+}
+
+func (l *logrusImpl) Warnf(format string, args ...interface{}) {
+	l.impl.Warnf(format, args...)
+}
+
+func (l *logrusImpl) Warnln(args ...interface{}) {
+	l.impl.Warnln(args...)
+}
+
+func (l *logrusImpl) Panic(args ...interface{}) {
+	l.impl.Panic(args...)
+}
+
+func (l *logrusImpl) Panicf(format string, args ...interface{}) {
+	l.impl.Panicf(format, args...)
+}
+
+func (l *logrusImpl) Panicln(args ...interface{}) {
+	l.impl.Panicln(args...)
+}
+
+func (l *logrusImpl) WithFields(fields map[string]interface{}) logger.Logger {
+	return &logrusImpl{impl: l.impl.WithFields(fields)}
+
+}
+func (l *logrusImpl) WithField(key string, value interface{}) logger.Logger {
+	return &logrusImpl{impl: l.impl.WithField(key, value)}
+}
+
+func (l *logrusImpl) WithError(err error) logger.Logger {
+	return &logrusImpl{impl: l.impl.WithError(err)}
+}

--- a/logger/null.go
+++ b/logger/null.go
@@ -1,0 +1,73 @@
+package logger
+
+// NullLogger ...
+type NullLogger struct{}
+
+// Fatal ...
+func (n *NullLogger) Fatal(format ...interface{}) {}
+
+// Fatalf ...
+func (n *NullLogger) Fatalf(format string, args ...interface{}) {}
+
+// Fatalln ...
+func (n *NullLogger) Fatalln(args ...interface{}) {}
+
+// Debug ...
+func (n *NullLogger) Debug(args ...interface{}) {}
+
+// Debugf ...
+func (n *NullLogger) Debugf(format string, args ...interface{}) {}
+
+// Debugln ...
+func (n *NullLogger) Debugln(args ...interface{}) {}
+
+// Error ...
+func (n *NullLogger) Error(args ...interface{}) {}
+
+// Errorf ...
+func (n *NullLogger) Errorf(format string, args ...interface{}) {}
+
+// Errorln ...
+func (n *NullLogger) Errorln(args ...interface{}) {}
+
+// Info ...
+func (n *NullLogger) Info(args ...interface{}) {}
+
+// Infof ...
+func (n *NullLogger) Infof(format string, args ...interface{}) {}
+
+// Infoln ...
+func (n *NullLogger) Infoln(args ...interface{}) {}
+
+// Warn ...
+func (n *NullLogger) Warn(args ...interface{}) {}
+
+// Warnf ...
+func (n *NullLogger) Warnf(format string, args ...interface{}) {}
+
+// Warnln ...
+func (n *NullLogger) Warnln(args ...interface{}) {}
+
+// Panic ...
+func (n *NullLogger) Panic(args ...interface{}) {}
+
+// Panicf ...
+func (n *NullLogger) Panicf(format string, args ...interface{}) {}
+
+// Panicln ...
+func (n *NullLogger) Panicln(args ...interface{}) {}
+
+// WithFields ...
+func (n *NullLogger) WithFields(fields map[string]interface{}) Logger {
+	return n
+}
+
+// WithField ...
+func (n *NullLogger) WithField(key string, value interface{}) Logger {
+	return n
+}
+
+// WithError ...
+func (n *NullLogger) WithError(err error) Logger {
+	return n
+}

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -51,7 +51,7 @@ func NewProducer(
 }
 
 func (p *Producer) configure() error {
-	c, err := client.NewClient("", p.config, p.log, nil)
+	c, err := client.New("", p.config, p.log, nil)
 	if err != nil {
 		return err
 	}

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -28,20 +28,19 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/topfreegames/eventsgateway/client"
-
-	"github.com/sirupsen/logrus"
+	"github.com/topfreegames/eventsgateway/logger"
 )
 
 // Producer is the app strupure
 type Producer struct {
-	log    logrus.FieldLogger
+	log    logger.Logger
 	config *viper.Viper
 	client *client.Client
 }
 
 // NewProducer creates test client
 func NewProducer(
-	log logrus.FieldLogger, config *viper.Viper,
+	log logger.Logger, config *viper.Viper,
 ) (*Producer, error) {
 	p := &Producer{
 		log:    log,

--- a/sender/kafka.go
+++ b/sender/kafka.go
@@ -14,10 +14,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	avro "github.com/topfreegames/avro/go/eventsgateway/generated"
 	"github.com/topfreegames/eventsgateway/forwarder"
+	"github.com/topfreegames/eventsgateway/logger"
 	kafka "github.com/topfreegames/go-extensions-kafka"
 	pb "github.com/topfreegames/protos/eventsgateway/grpc/generated"
 	"google.golang.org/grpc/codes"
@@ -26,14 +26,14 @@ import (
 
 type KafkaSender struct {
 	config      *viper.Viper
-	logger      logrus.FieldLogger
+	logger      logger.Logger
 	producer    forwarder.Forwarder
 	topicPrefix string
 }
 
 func NewKafkaSender(
 	producer forwarder.Forwarder,
-	logger logrus.FieldLogger,
+	logger logger.Logger,
 	config *viper.Viper,
 ) *KafkaSender {
 	k := &KafkaSender{producer: producer, logger: logger, config: config}
@@ -69,7 +69,7 @@ func (k *KafkaSender) SendEvent(
 	ctx context.Context,
 	event *pb.Event,
 ) error {
-	l := k.logger.WithFields(logrus.Fields{
+	l := k.logger.WithFields(map[string]interface{}{
 		"topic": event.GetTopic(),
 		"event": event,
 	})
@@ -114,7 +114,7 @@ func (k *KafkaSender) SendEvent(
 	if err != nil {
 		return err
 	}
-	l.WithFields(logrus.Fields{
+	l.WithFields(map[string]interface{}{
 		"partition": partition,
 		"offset":    offset,
 	}).Debug("event sent to kafka")


### PR DESCRIPTION
This PR removes logrus from eventsgateway API and uses a generic logger interface instead. The objective is to not enforce the usage of any specific logging solution.

In order to achieve this, I created a new `logger.Logger` interface, which replaces `logrus.FieldLogger`.

Considering better retro compatibility, I've decided to keep the old eventsgateway client constructor and also provide a default logrus implementation of the `logger.Logger` interface.