### PR TITLE
Make metrics server opt in

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -54,7 +54,7 @@ var startCmd = &cobra.Command{
 			log.Panic(err)
 		}
 		launchPProf()
-		metrics.StartServer()
+		launchMetricsServer()
 		a.Run()
 	},
 }
@@ -66,6 +66,12 @@ func launchPProf() {
 	if config.GetBool("pprof.enabled") {
 		professor.Launch(config.GetString("pprof.address"))
 	}
+}
+
+func launchMetricsServer() {
+	fmt.Println("Starting Metrics HTTP server")
+	config.SetDefault("prometheus.port", ":9091")
+	metrics.StartServer(config.GetString("prometheus.port"))
 }
 
 func init() {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -30,6 +30,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/topfreegames/eventsgateway/app"
 	logruswrapper "github.com/topfreegames/eventsgateway/logger/logrus"
+	"github.com/topfreegames/eventsgateway/metrics"
 )
 
 var host string
@@ -53,6 +54,7 @@ var startCmd = &cobra.Command{
 			log.Panic(err)
 		}
 		launchPProf()
+		metrics.StartServer()
 		a.Run()
 	},
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -123,7 +123,10 @@ var (
 	)
 )
 
-func init() {
+// StartServer runs a metrics server inside a goroutine
+// that reports default application metrics in prometheus format.
+// Any errors that may occur will stop the server add log.Fatal the error.
+func StartServer() {
 	prometheus.MustRegister(
 		APIResponseTime,
 		APIRequestsFailureCounter,
@@ -139,8 +142,8 @@ func init() {
 		port = fmt.Sprintf(":%s", envPort)
 	}
 	go func() {
-		envDisabled, _ := os.LookupEnv("EVENTSGATEWAY_PROMETHEUS_DISABLED")
-		if envDisabled == "true" {
+		envEnabled, _ := os.LookupEnv("EVENTSGATEWAY_PROMETHEUS_ENABLED")
+		if envEnabled == "false" {
 			return
 		}
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -23,7 +23,6 @@
 package metrics
 
 import (
-	"fmt"
 	"net/http"
 	"os"
 	"time"
@@ -126,7 +125,7 @@ var (
 // StartServer runs a metrics server inside a goroutine
 // that reports default application metrics in prometheus format.
 // Any errors that may occur will stop the server add log.Fatal the error.
-func StartServer() {
+func StartServer(port string) {
 	prometheus.MustRegister(
 		APIResponseTime,
 		APIRequestsFailureCounter,
@@ -137,10 +136,6 @@ func StartServer() {
 		ClientRequestsFailureCounter,
 		ClientRequestsDroppedCounter,
 	)
-	port := ":9091"
-	if envPort, ok := os.LookupEnv("EVENTSGATEWAY_PROMETHEUS_PORT"); ok {
-		port = fmt.Sprintf(":%s", envPort)
-	}
 	go func() {
 		envEnabled, _ := os.LookupEnv("EVENTSGATEWAY_PROMETHEUS_ENABLED")
 		if envEnabled != "true" {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -143,7 +143,7 @@ func StartServer() {
 	}
 	go func() {
 		envEnabled, _ := os.LookupEnv("EVENTSGATEWAY_PROMETHEUS_ENABLED")
-		if envEnabled == "false" {
+		if envEnabled != "true" {
 			return
 		}
 


### PR DESCRIPTION
The metrics server is now opt-in to avoid miss usage for users that only require the client package.