### PR TITLE
feat(client): enable gzip encoding

### DIFF
--- a/config/local.yaml
+++ b/config/local.yaml
@@ -19,6 +19,8 @@ client:
     time: 60s
     timeout: 15s
     permitwithoutstreams: true
+  gzip:
+    enabled: false
   grpc:
     serverAddress: eventsgateway-api:5000 #eventsgateway-api:5000
     timeout: 500ms

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -11,6 +11,8 @@ client:
   maxRetries: 3
   numRoutines: 1
   retryInterval: 1s
+  gzip:
+    enabled: false
   grpc:
     serverAddress: eventsgateway-api:5000
     timeoutms: 500ms

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -39,6 +39,10 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/propagation"
 
+	// Installing the gzip encoding registers it as an available compressor.
+	// gRPC will automatically negotiate and use gzip if the client supports it.
+	_ "google.golang.org/grpc/encoding/gzip"
+
 	goMetrics "github.com/rcrowley/go-metrics"
 	"github.com/topfreegames/eventsgateway/v4/server/logger"
 	"github.com/topfreegames/eventsgateway/v4/server/metrics"


### PR DESCRIPTION
## Motivation

Some servers can send a huge payload and even though we leverage protobuf from GRPC we can compress even further with Gzip. This is specifically useful in cloud-native scenarios where services might be billed for Data Transfer across clusters/zones.

## How it was achieved

If the client enables gzip via env var `client.gzip.enabled` (string representing bool) then gzip will be enabled by default in all GRPC calls via DialOptions. Servers created via grpc.NewServer() will have a gzip compressor by default if imported as per:

https://github.com/grpc/grpc-go/blob/master/examples/features/compression/server/main.go#L33

Ref of Gzip compression in GRPC:
* https://grpc.io/docs/guides/compression/
* https://github.com/grpc/grpc-go/blob/master/Documentation/compression.md