### PR TITLE
fix: replace satori/go.uuid for gofrs/uuid

### DIFF
--- a/client/async.go
+++ b/client/async.go
@@ -10,12 +10,13 @@ package client
 import (
 	"context"
 	"fmt"
-	"google.golang.org/grpc/credentials/insecure"
 	"math"
 	"sync"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"google.golang.org/grpc/credentials/insecure"
+
+	uuid "github.com/gofrs/uuid/v5"
 	"github.com/spf13/viper"
 	"github.com/topfreegames/eventsgateway/v4/logger"
 	"github.com/topfreegames/eventsgateway/v4/metrics"
@@ -200,7 +201,8 @@ func (a *gRPCClientAsync) sendRoutine() {
 
 	send := func() {
 		cpy := req
-		cpy.Id = uuid.NewV4().String()
+		uuidV4, _ := uuid.NewV4()
+		cpy.Id = uuidV4.String()
 		req = &pb.SendEventsRequest{}
 		req.Events = make([]*pb.Event, 0, a.batchSize)
 		go a.sendEvents(cpy, 0)

--- a/client/client.go
+++ b/client/client.go
@@ -22,7 +22,7 @@ import (
 	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/keepalive"
 
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/gofrs/uuid/v5"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/topfreegames/eventsgateway/v4/logger"
@@ -227,8 +227,9 @@ func (c *Client) GracefulStop() error {
 }
 
 func buildEvent(name string, props map[string]string, topic string, time time.Time) *pb.Event {
+	uuidV4, _ := uuid.NewV4()
 	return &pb.Event{
-		Id:        uuid.NewV4().String(),
+		Id:        uuidV4.String(),
 		Name:      name,
 		Topic:     topic,
 		Props:     props,

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/Shopify/sarama v1.35.0
+	github.com/gofrs/uuid/v5 v5.3.2
 	github.com/golang/mock v1.4.4
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
@@ -12,7 +13,6 @@ require (
 	github.com/onsi/gomega v1.20.0
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/prometheus/client_golang v1.14.0
-	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v0.0.1
 	github.com/spf13/viper v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/gofrs/uuid/v5 v5.3.2 h1:2jfO8j3XgSwlz/wHqemAEugfnTlikAYHhnqQ8Xh4fE0=
+github.com/gofrs/uuid/v5 v5.3.2/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -322,8 +324,6 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/tools/runner.go
+++ b/tools/runner.go
@@ -24,11 +24,12 @@ package tools
 
 import (
 	"context"
-	"github.com/opentracing/opentracing-go"
 	"math/rand"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/opentracing/opentracing-go"
+
+	uuid "github.com/gofrs/uuid/v5"
 	"github.com/spf13/viper"
 	"github.com/topfreegames/eventsgateway/v4/client"
 	"github.com/topfreegames/eventsgateway/v4/logger"
@@ -127,7 +128,9 @@ func buildProps(size string) map[string]string {
 	}
 	props := map[string]string{}
 	for i := 0; i < n; i++ {
-		props[uuid.NewV4().String()] = uuid.NewV4().String()
+		uuidV4a, _ := uuid.NewV4()
+		uuidV4b, _ := uuid.NewV4()
+		props[uuidV4a.String()] = uuidV4b.String()
 	}
 	return props
 }


### PR DESCRIPTION
[satori/go.uuid](https://github.com/satori/go.uuid) has been abandoned for many years, and the community forked into [gofrs/uuid](https://github.com/gofrs/uuid/), which is currently maintained and updated. 

I'm changing this dep mostly because the older one gets frequently reported as containing a 9.8 CVE, which triggers alerts over systems that monitor for it.